### PR TITLE
Handle minio chunked

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ The following code block shows the structure of the configuration file and provi
         // The size of the buffer when calling PutObject.
         "put_object_buffer_size_in_bytes": 8192,
 
+        // When the HTTP parser requests a larger buffer, the buffer size is
+        // doubled. This option specifies the largest the buffer will grow.
+        "put_object_max_buffer_size_in_bytes": 65536,
+
         // The size of the buffer when calling GetObject.
         "get_object_buffer_size_in_bytes": 8192,
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,16 @@ config = TransferConfig(multipart_threshold=5*1024*1024*1024)
 self.boto3_client.upload_file(put_filename, bucket_name, key, Config=config)
 ```
 
+### Example of MinIO mc client
+
+The `mc cp` command has a `--disable-multipart` option for file uploads.  Here is an example of an upload with a `myminio` alias:
+
+```bash
+mc cp --disable-multipart put_file myminio/bucket_name/put_filename
+```
+
+*Note: MinIO client uses aliases to group URL and keys. Refer to the `mc alias` command for information on setting, listing, and removing aliases.*
+
 ## Running Tests
 
 Run the following commands to run the test suite.

--- a/config.json.template
+++ b/config.json.template
@@ -26,6 +26,7 @@
         "threads": 10,
 
         "put_object_buffer_size_in_bytes": 8192,
+        "put_object_max_buffer_size_in_bytes": 65536,
         "get_object_buffer_size_in_bytes": 8192,
         "region": "us-east-1"
     },

--- a/src/common_routines.hpp
+++ b/src/common_routines.hpp
@@ -6,7 +6,7 @@
 
 namespace irods::s3::api::common_routines {
 
-    inline std::string convert_time_t_to_str(const time_t& t, const std::string& format) {
+    inline std::string convert_time_t_to_str(const time_t& t, const std::string_view format) {
         return fmt::format(fmt::runtime(format), fmt::localtime(t));
     }
 }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -8,6 +8,7 @@ namespace
     nlohmann::json g_config;
     std::optional<std::string> resource;
     std::optional<uint64_t> put_object_buffer_size_in_bytes;
+    std::optional<uint64_t> put_object_max_buffer_size_in_bytes;
     std::optional<uint64_t> get_object_buffer_size_in_bytes;
     std::optional<std::string> s3_region;
 } //namespace
@@ -29,6 +30,15 @@ uint64_t irods::s3::get_put_object_buffer_size_in_bytes()
                 nlohmann::json::json_pointer{"/s3_server/put_object_buffer_size_in_bytes"}, 8192);
     }
     return put_object_buffer_size_in_bytes.value();
+}
+
+uint64_t irods::s3::get_put_object_max_buffer_size_in_bytes()
+{
+    if (!put_object_max_buffer_size_in_bytes.has_value()) {
+        put_object_max_buffer_size_in_bytes = g_config.value(
+                nlohmann::json::json_pointer{"/s3_server/put_object_max_buffer_size_in_bytes"}, 65536);
+    }
+    return put_object_max_buffer_size_in_bytes.value();
 }
 
 uint64_t irods::s3::get_get_object_buffer_size_in_bytes()

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -12,6 +12,7 @@ namespace irods::s3
     std::string get_resource();
 
     uint64_t get_put_object_buffer_size_in_bytes();
+    uint64_t get_put_object_max_buffer_size_in_bytes();
     uint64_t get_get_object_buffer_size_in_bytes();
 
     std::string get_s3_region();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ asio::awaitable<void> handle_request(asio::ip::tcp::socket socket)
     boost::system::error_code ec;
     std::cout << "Received " << beast::http::read_header(socket, buffer, parser, ec) << " bytes\n";
     if (ec) {
+        std::cout << "ERROR READING HEADER!!!" << std::endl;
         // handle me please!
     }
     for (const auto& field : parser.get()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,9 +56,13 @@ asio::awaitable<void> handle_request(asio::ip::tcp::socket socket)
     boost::system::error_code ec;
     std::cout << "Received " << beast::http::read_header(socket, buffer, parser, ec) << " bytes\n";
     if (ec) {
-        std::cout << "ERROR READING HEADER!!!" << std::endl;
-        // handle me please!
+        std::cerr << "Error reading header: " << ec.message() << std::endl;
+        beast::http::response<beast::http::empty_body> response;
+        response.result(beast::http::status::internal_server_error);
+        beast::http::write(socket, response);
+        co_return;
     }
+
     for (const auto& field : parser.get()) {
         std::cout << "header: " << field.name_string() << ":" << field.value() << std::endl;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,8 +156,6 @@ asio::awaitable<void> handle_request(asio::ip::tcp::socket socket)
             break;
         case boost::beast::http::verb::head:
             // Probably just headbucket and headobject here.
-            // and headbucket isn't on the immediate list
-            // of endpoints.
             if (1 == url.segments().size()) {
                 std::cout << "Headbucket detected" << std::endl;
                 co_await irods::s3::actions::handle_headbucket(socket, parser, url);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,8 +158,10 @@ asio::awaitable<void> handle_request(asio::ip::tcp::socket socket)
             // Probably just headbucket and headobject here.
             // and headbucket isn't on the immediate list
             // of endpoints.
-            if (url.segments().empty()) {
+            if (1 == url.segments().size()) {
                 std::cout << "Headbucket detected" << std::endl;
+                co_await irods::s3::actions::handle_headbucket(socket, parser, url);
+                co_return;
             }
             else {
                 std::cout << "Headobject detected" << std::endl;

--- a/src/s3/CMakeLists.txt
+++ b/src/s3/CMakeLists.txt
@@ -6,4 +6,6 @@ target_sources(
   getobject.cpp
   putobject.cpp
   deleteobject.cpp
-  headobject.cpp copyobject.cpp)
+  headobject.cpp
+  headbucket.cpp
+  copyobject.cpp)

--- a/src/s3/headbucket.cpp
+++ b/src/s3/headbucket.cpp
@@ -1,0 +1,69 @@
+#include "./s3_api.hpp"
+#include "../authentication.hpp"
+#include "../bucket.hpp"
+#include "../common_routines.hpp"
+
+#include <irods/irods_exception.hpp>
+
+#include <fmt/format.h>
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+namespace fs = irods::experimental::filesystem;
+
+boost::asio::awaitable<void> irods::s3::actions::handle_headbucket(
+    boost::asio::ip::tcp::socket& socket,
+    static_buffer_request_parser& parser,
+    const boost::urls::url_view& url)
+{
+    auto conn = irods::s3::get_connection();
+    beast::http::response<beast::http::empty_body> response;
+    response.result(beast::http::status::forbidden);
+    try {
+        auto irods_username = irods::s3::authentication::authenticates(*conn, parser, url);
+
+        if (!irods_username) {
+            response.result(beast::http::status::forbidden);
+        }
+        else {
+            // Reconnect to the iRODS server as the target user.
+            // The rodsadmin account from the config file will act as the proxy for the user.
+            conn = irods::s3::get_connection(irods_username);
+
+            fs::path path;
+            if (auto bucket = irods::s3::resolve_bucket(*conn, url.segments()); bucket.has_value()) {
+                path = irods::s3::finish_path(bucket.value(), url.segments());
+            }
+            else {
+                std::cout << "Failed to resolve bucket" << std::endl;
+                response.result(beast::http::status::forbidden);
+                beast::http::write(socket, response);
+                co_return;
+            }
+            if (fs::client::exists(*conn, path)) {
+                response.result(boost::beast::http::status::ok);
+                std::cout << response.result() << std::endl;
+            } else {
+                // This could be that it doesn't exist or that the user doesn't have permission.
+                // Returning forbidden. 
+                response.result(boost::beast::http::status::forbidden);
+            }
+        }
+    }
+    catch (const std::system_error& e) {
+        std::cout << e.what() << std::endl;
+        switch (e.code().value()) {
+            case USER_ACCESS_DENIED:
+            case CAT_NO_ACCESS_PERMISSION:
+                response.result(beast::http::status::forbidden);
+                break;
+            default:
+                response.result(beast::http::status::internal_server_error);
+                break;
+        }
+    }
+
+    beast::http::write(socket, response);
+
+    co_return;
+}

--- a/src/s3/headobject.cpp
+++ b/src/s3/headobject.cpp
@@ -14,19 +14,19 @@ namespace asio = boost::asio;
 namespace beast = boost::beast;
 namespace fs = irods::experimental::filesystem;
 
-static const std::string date_format{"{:%a, %d %b %Y %H:%M:%S GMT}"};
+const static std::string_view date_format{"{:%a, %d %b %Y %H:%M:%S GMT}"};
 
 boost::asio::awaitable<void> irods::s3::actions::handle_headobject(
     boost::asio::ip::tcp::socket& socket,
     static_buffer_request_parser& parser,
     const boost::urls::url_view& url)
 {
-    auto thing = irods::s3::get_connection();
+    auto conn = irods::s3::get_connection();
     beast::http::response<beast::http::empty_body> response;
     response.result(beast::http::status::forbidden);
     // TODO I think the operations in this block can be unwrapped safely
     try {
-        auto irods_username = irods::s3::authentication::authenticates(*thing, parser, url);
+        auto irods_username = irods::s3::authentication::authenticates(*conn, parser, url);
 
         if (!irods_username) {
             response.result(beast::http::status::forbidden);
@@ -34,10 +34,10 @@ boost::asio::awaitable<void> irods::s3::actions::handle_headobject(
         else {
             // Reconnect to the iRODS server as the target user.
             // The rodsadmin account from the config file will act as the proxy for the user.
-            thing = irods::s3::get_connection(irods_username);
+            conn = irods::s3::get_connection(irods_username);
 
             fs::path path;
-            if (auto bucket = irods::s3::resolve_bucket(*thing, url.segments()); bucket.has_value()) {
+            if (auto bucket = irods::s3::resolve_bucket(*conn, url.segments()); bucket.has_value()) {
                 path = bucket.value();
                 path = irods::s3::finish_path(path, url.segments());
             }
@@ -47,24 +47,24 @@ boost::asio::awaitable<void> irods::s3::actions::handle_headobject(
             bool can_see = false;
             std::cout << "Tryna perm" << std::endl;
 
-            if (fs::client::exists(*thing, path)) {
+            if (fs::client::exists(*conn, path)) {
                 std::cout << "Found it?" << std::endl;
 
                 // Ideally in the future exists won't return true on things that you're not allowed to see,
                 // But until then, check for any mentioned permission.
-                auto all_permissions = fs::client::status(*thing, path).permissions();
+                auto all_permissions = fs::client::status(*conn, path).permissions();
                 for (const auto& i : all_permissions) {
-                    if (i.name == thing->clientUser.userName) {
+                    if (i.name == conn->clientUser.userName) {
                         can_see = true;
                     }
                 }
                 response.result(can_see ? boost::beast::http::status::ok : boost::beast::http::status::forbidden);
                 std::cout << response.result() << std::endl;
 
-                std::string length_field = std::to_string(irods::experimental::filesystem::client::data_object_size(*thing, path));
+                std::string length_field = std::to_string(irods::experimental::filesystem::client::data_object_size(*conn, path));
                 response.insert(beast::http::field::content_length, length_field);
 
-                auto last_write_time__time_point = irods::experimental::filesystem::client::last_write_time(*thing, path);
+                auto last_write_time__time_point = irods::experimental::filesystem::client::last_write_time(*conn, path);
                 std::time_t last_write_time__time_t = std::chrono::system_clock::to_time_t(last_write_time__time_point);
                 std::string last_write_time__str = irods::s3::api::common_routines::convert_time_t_to_str(last_write_time__time_t, date_format);
                 response.insert(beast::http::field::last_modified, last_write_time__str);

--- a/src/s3/listobjects.cpp
+++ b/src/s3/listobjects.cpp
@@ -28,7 +28,7 @@
 namespace asio = boost::asio;
 namespace beast = boost::beast;
 
-static const std::string date_format{"{:%Y-%m-%dT%H:%M:%S.000Z}"};
+const static std::string_view date_format{"{:%Y-%m-%dT%H:%M:%S.000Z}"};
 
 asio::awaitable<void> irods::s3::actions::handle_listobjects_v2(
     asio::ip::tcp::socket& socket,

--- a/src/s3/putobject.cpp
+++ b/src/s3/putobject.cpp
@@ -28,15 +28,46 @@ asio::awaitable<void> irods::s3::actions::handle_putobject(
 {
     boost::beast::error_code ec;
     connection_handle connection = get_connection();
+    auto& parser_message = parser.get();
 
-    std::cout << "Hi! About to auth" << std::endl;
+    // Look for the header that MinIO sends for chunked data.  If it exists we
+    // have to parse chunks ourselves.
+    bool special_chunked_header = false;
+    auto header = parser_message.find("x-Amz-Content-Sha256");
+    if (header != parser_message.end() && header->value() == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD") {
+        special_chunked_header = true;
+    }
+    std::cout << "special_chunked_header: " << special_chunked_header << std::endl;
 
+    // See if we have chunked set.  If so turn off special chunked header flag as the
+    // parser will handle it.
+    bool chunked_flag = false;
+    if (parser_message[beast::http::field::transfer_encoding] == "chunked") {
+        special_chunked_header = false;
+        chunked_flag = true;
+    }
+
+    // If chunked_flag is false, make sure we have Content-Length or
+    // we will not be able to parse the response as the parser will return
+    // immediately.  If we have special_chunked header we still need
+    // the Content-Length.
+    if (!chunked_flag) {
+        header = parser_message.find("Content-Length");
+        if (header == parser_message.end()) {
+            beast::http::response<boost::beast::http::empty_body> response;
+            response.result(boost::beast::http::status::bad_request);
+            beast::http::write(socket, response);
+            std::cout << "Neither Content-Length nor chunked mode were set." << std::endl;
+            co_return;
+        }
+    }
+
+    // Authenticate
     auto irods_username = irods::s3::authentication::authenticates(*connection, parser, url);
 
     if (!irods_username) {
         beast::http::response<boost::beast::http::empty_body> response;
         response.result(boost::beast::http::status::forbidden);
-        beast::http::write(socket, response);
         beast::http::write(socket, response);
         std::cout << "Failed to auth" << std::endl;
         co_return;
@@ -46,11 +77,11 @@ asio::awaitable<void> irods::s3::actions::handle_putobject(
     // The rodsadmin account from the config file will act as the proxy for the user.
     connection = irods::s3::get_connection(irods_username);
 
-    if (parser.get()[beast::http::field::expect] == "100-continue") {
+    if (parser_message[beast::http::field::expect] == "100-continue") {
         beast::http::response<beast::http::empty_body> resp;
         resp.version(11);
         resp.result(beast::http::status::continue_);
-        resp.set(beast::http::field::server, parser.get()["Host"]);
+        resp.set(beast::http::field::server, parser_message["Host"]);
         beast::http::write(socket, resp, ec);
         std::cout << "Sent 100-continue" << std::endl;
     }
@@ -88,36 +119,233 @@ asio::awaitable<void> irods::s3::actions::handle_putobject(
         }
 
         uint64_t read_buffer_size = irods::s3::get_put_object_buffer_size_in_bytes();
+        uint64_t max_read_buffer_size = irods::s3::get_put_object_max_buffer_size_in_bytes();
         std::cout << "read buffer size = " << read_buffer_size << std::endl;
+        std::cout << "max read buffer size = " << max_read_buffer_size << std::endl;
         std::vector<char> buf_vector(read_buffer_size);
-        parser.get().body().data = buf_vector.data();
-        parser.get().body().size = read_buffer_size; 
+        parser_message.body().data = buf_vector.data();
+        parser_message.body().size = read_buffer_size; 
 
         response.set("Etag", path.c_str());
         response.set("Connection", "close");
 
-        while (!parser.is_done()) {
-            parser.get().body().data = buf_vector.data();
-            parser.get().body().size = read_buffer_size;
-            //            auto read = co_await beast::http::async_read_some(socket, buffer, parser,
-            //            asio::use_awaitable);
-            auto read = beast::http::read_some(socket, buffer, parser);
-            size_t read_bytes = read_buffer_size - parser.get().body().size;
+        if (special_chunked_header) {
+            std::cout << "read buffer size = " << read_buffer_size << std::endl;
 
-            try {
-                d.write((char*) buf_vector.data(), read_bytes);
-            }
-            catch (std::exception& e) {
-                std::cout << e.what() << std::endl;
+
+            boost::beast::error_code ec;
+
+            enum class parsing_state {
+                header_begin, header_continue, body, end_of_chunk, parsing_done, parsing_error
+            };
+
+            parsing_state current_state = parsing_state::header_begin;
+            std::string the_bytes;
+
+            size_t chunk_size = 0;
+
+            // While we have more data to be read from the socket into the_bytes or
+            // we haven't exhausted the_bytes.
+            while (!parser.is_done() || !the_bytes.empty()) {
+
+                // check to see if we are done parsing the chunks
+                if (current_state == parsing_state::parsing_done || current_state == parsing_state::parsing_error) {
+                    break;
+                }
+
+                parser_message.body().data = buf_vector.data();
+                parser_message.body().size = read_buffer_size;
+                
+                if (!parser.is_done()) {
+                    // The eager option instructs the parser to continue reading the buffer once it has completed a
+                    // structured element (header, chunk header, chunk body). Since we are handling the parsing ourself,
+                    // we want the parser to give us as much as is available.
+                    parser.eager(true);
+                    co_await beast::http::read_some(socket, buffer, parser, ec);
+
+                    // The need_buffer exception is an indication that the current buffer
+                    // is not large enough for the parser to handle the request.  Double
+                    // the buffer size up to a maximum allowed buffer size.
+                    if(ec == beast::http::error::need_buffer) {
+                        read_buffer_size *= 2;
+                        if (read_buffer_size > max_read_buffer_size) {
+                            read_buffer_size = max_read_buffer_size;
+                        }
+                        buf_vector.resize(read_buffer_size);
+                        std::cout << "read buffer size updated to " << read_buffer_size << std::endl;
+                        ec = {};
+                    }
+                    if(ec) {
+                        beast::http::response<beast::http::empty_body> response;
+                        response.result(beast::http::status::internal_server_error);
+                        std::cerr << "Error reading data" << std::endl;
+                        beast::http::write(socket, response);
+                        co_return;
+                    }
+                }
+
+                size_t read_bytes = read_buffer_size - parser_message.body().size;
+                the_bytes.append(buf_vector.data(), read_bytes);
+
+                switch (current_state) {
+                    case parsing_state::header_begin:
+                    {
+                        // Chunk headers can be of the following forms:
+                        // 1. With extensions: <hex>;extension1=extension1value;extension2=extension2value\r\n
+                        // 2. Without extensions: <hex>\r\n
+                        
+                        // See if it is of form 1.
+                        size_t colon_location = the_bytes.find (";");
+                        if (colon_location == std::string::npos) {
+
+                            // Not form 1.  See if it is form 2.
+                            size_t newline_location = the_bytes.find("\r\n");
+                            if (newline_location != std::string::npos) {
+                                std::string chunk_size_str = the_bytes.substr(0, newline_location);
+                                size_t hex_digits_parsed = 0;
+                                try {
+                                    chunk_size = stoull(chunk_size_str, &hex_digits_parsed, 16);
+                                } catch (std::invalid_argument& e) {
+                                    hex_digits_parsed = 0;
+                                }
+
+                                if (hex_digits_parsed == chunk_size_str.length()) {
+                                    // eat the bytes up to and including \r\n 
+                                    the_bytes = the_bytes.substr(newline_location+2);
+                                    if (chunk_size == 0) {
+                                        current_state = parsing_state::parsing_done;
+                                    } else {
+                                        current_state = parsing_state::body;
+                                    }
+                                } else {
+                                    std::cout << "Bad chunk size: " << chunk_size_str << std::endl;
+                                    current_state = parsing_state::parsing_error;
+                                }
+                            }   
+                        } else {
+                            std::string chunk_size_str = the_bytes.substr(0, colon_location);
+                            size_t hex_digits_parsed = 0;
+                            try {
+                               chunk_size = stoull(chunk_size_str, &hex_digits_parsed, 16);
+                            } catch (std::invalid_argument& e) {
+                                hex_digits_parsed = 0;
+                            }
+                            if (hex_digits_parsed == chunk_size_str.length()) {
+                                // eat the bytes up to and including colon
+                                the_bytes = the_bytes.substr(colon_location+1);
+                                current_state = parsing_state::header_continue;
+                            } else {
+                                std::cout << "Bad chunk size: " << chunk_size_str << std::endl;
+                                current_state = parsing_state::parsing_error;
+                            }
+                        }
+                        break;
+                    }
+                    case parsing_state::header_continue:
+                    {
+                        // move beyond the newline 
+                        size_t newline_location = the_bytes.find("\r\n");
+
+                        // reset string stream and set it to after the \r\n
+                        if (newline_location != std::string::npos) {
+                            the_bytes = the_bytes.substr(newline_location+2);
+                            if (chunk_size == 0) {
+                                current_state = parsing_state::parsing_done;
+                            } else {
+                                current_state = parsing_state::body;
+                            }
+                        }
+                        break;
+                    }
+                    case parsing_state::body:
+                    {
+                        size_t ss_size = the_bytes.length();
+
+                        // if we have the full chunk, handle it otherwise continue
+                        // until we do
+                        if (ss_size >= chunk_size) {
+                            std::string body = the_bytes.substr(0, chunk_size);
+
+                            try {
+                                d.write(body.c_str(), body.length());
+                            }
+                            catch (std::exception& e) {
+                                std::cout << e.what() << std::endl;
+                            }
+
+                            // reset string stream and set it to after the \r\n
+                            the_bytes = the_bytes.substr(chunk_size);
+                            current_state = parsing_state::end_of_chunk;
+                        }
+                        break;
+                    }
+                    case parsing_state::end_of_chunk:
+                    {
+                        size_t newline_location = the_bytes.find("\r\n");
+                        if (newline_location != 0) {
+                            std::cout << "Invalid chunk end sequence" << std::endl;
+                            current_state = parsing_state::parsing_error;
+                        } else {
+                            // remove \r\n and go to next chunk
+                            the_bytes = the_bytes.substr(2);
+                            current_state = parsing_state::header_begin;
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+
+                };
+
             }
 
-            if (ec == beast::http::error::need_buffer) {
-                ec = {};
-            }
-            else if (ec) {
-                std::cout << ec.what() << std::endl;
+            if (current_state == parsing_state::parsing_error) {
+                beast::http::response<boost::beast::http::empty_body> response;
+                response.result(boost::beast::http::status::bad_request);
+                beast::http::write(socket, response);
+                std::cout << "Error parsing chunked body." << std::endl;
                 co_return;
             }
+
+        } else {
+            // Let boost::beast::parser handle the body
+            while (!parser.is_done()) {
+                
+                parser_message.body().data = buf_vector.data();
+                parser_message.body().size = read_buffer_size;
+                co_await beast::http::read_some(socket, buffer, parser, ec);
+                size_t read_bytes = read_buffer_size - parser_message.body().size;
+
+                std::string the_bytes{buf_vector.data(), read_bytes};
+
+                // The need_buffer exception is an indication that the current buffer
+                // is not large enough for the parser to handle the request.  Double
+                // the buffer size up to a maximum allowed buffer size.
+                if (ec == beast::http::error::need_buffer) {
+                    if (read_buffer_size < max_read_buffer_size) {
+                        read_buffer_size *= 2;
+                        if (read_buffer_size > max_read_buffer_size) {
+                            read_buffer_size = max_read_buffer_size;
+                        }
+                        buf_vector.resize(read_buffer_size);
+                        std::cout << "read buffer size updated to " << read_buffer_size << std::endl;
+                        ec = {};
+                    }
+                }
+
+                if (ec) {
+                    std::cout << ec.what() << std::endl;
+                    co_return;
+                }
+
+                try {
+                    d.write((char*) buf_vector.data(), read_bytes);
+                }
+                catch (std::exception& e) {
+                    std::cout << e.what() << std::endl;
+                }
+
+             }
         }
 
         beast::http::write(socket, response, ec);

--- a/src/s3/s3_api.hpp
+++ b/src/s3/s3_api.hpp
@@ -43,6 +43,11 @@ namespace irods::s3::actions
         static_buffer_request_parser& parser,
         const boost::urls::url_view& url);
 
+    boost::asio::awaitable<void> handle_headbucket(
+        boost::asio::ip::tcp::socket& socket,
+        static_buffer_request_parser& parser,
+        const boost::urls::url_view& url);
+
     boost::asio::awaitable<void> handle_copyobject(
         boost::asio::ip::tcp::socket& socket,
         static_buffer_request_parser& parser,

--- a/tests/copyobject_test.py
+++ b/tests/copyobject_test.py
@@ -41,7 +41,7 @@ class CopyObject_Test(TestCase):
                                   secure=False)
 
     def tearDown(self):
-        pass
+        self.boto3_client.close()
 
     def test_botocore_copy_object_root_small_file(self):
 

--- a/tests/deleteobject_test.py
+++ b/tests/deleteobject_test.py
@@ -31,9 +31,8 @@ class DeleteObject_Test(TestCase):
                                         aws_access_key_id=self.key,
                                         aws_secret_access_key=self.secret_key)
 
-    @classmethod 
     def tearDown(self):
-        pass
+        self.boto3_client.close()
 
     # ======== Tests =========
 

--- a/tests/docker/config.json
+++ b/tests/docker/config.json
@@ -31,6 +31,7 @@
 
         "threads": 10,
         "put_object_buffer_size_in_bytes": 8192,
+        "put_object_max_buffer_size_in_bytes": 65536,
         "get_object_buffer_size_in_bytes": 8192 
     },
 

--- a/tests/getobject_test.py
+++ b/tests/getobject_test.py
@@ -35,7 +35,7 @@ class GetObject_Test(TestCase):
                                   secure=False)
 
     def tearDown(self):
-        pass
+        self.boto3_client.close()
 
     def test_botocore_get_in_bucket_root_small_file(self):
 

--- a/tests/headbucket_test.py
+++ b/tests/headbucket_test.py
@@ -1,0 +1,84 @@
+from unittest import *
+import boto3
+import botocore
+import inspect
+import os
+from libs.execute import *
+from libs.command import *
+from libs.utility import *
+from datetime import datetime
+
+class HeadBucket_Test(TestCase):
+
+    # ======== Construction, setUp, tearDown =========
+    rods_key = 's3_key1'
+    rods_secret_key = 's3_secret_key1'
+    alice_key = 's3_key2'
+    alice_secret_key = 's3_secret_key2'
+    s3_api_url = 'http://s3-api:8080'
+
+    def __init__(self, *args, **kwargs):
+        super(HeadBucket_Test, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+
+        self.boto3_client_rods = boto3.client('s3',
+                                        use_ssl=False,
+                                        endpoint_url=self.s3_api_url,
+                                        aws_access_key_id=self.rods_key,
+                                        aws_secret_access_key=self.rods_secret_key)
+
+        self.boto3_client_alice = boto3.client('s3',
+                                        use_ssl=False,
+                                        endpoint_url=self.s3_api_url,
+                                        aws_access_key_id=self.alice_key,
+                                        aws_secret_access_key=self.alice_secret_key)
+
+    def tearDown(self):
+        self.boto3_client_rods.close()
+        self.boto3_client_alice.close()
+
+    # ======== Tests =========
+
+    # Note:  Minio mc client does not have a head-object command but this is called behind the
+    # scenes on other tests such as list-object.
+
+    def test_botocore_head_bucket_as_rods_user(self):
+        # rods can see test-bucket
+        head_bucket_result = self.boto3_client_rods.head_bucket(Bucket='test-bucket')
+        self.assertEqual(head_bucket_result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        # rods can see alice-bucket
+        head_bucket_result = self.boto3_client_rods.head_bucket(Bucket='alice-bucket')
+        self.assertEqual(head_bucket_result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        # rods can see alice-bucket2
+        head_bucket_result = self.boto3_client_rods.head_bucket(Bucket='alice-bucket2')
+        self.assertEqual(head_bucket_result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        # bucket does not exist
+        with self.assertRaises(botocore.exceptions.ClientError) as e:
+            self.boto3_client_rods.head_bucket(Bucket='bucketdoesnotexist')
+        the_exception = e.exception
+        self.assertEqual(the_exception.response['ResponseMetadata']['HTTPStatusCode'], 403)
+
+    def test_botocore_head_bucket_as_alice_user(self):
+        # alice can't see test-bucket
+        with self.assertRaises(botocore.exceptions.ClientError) as e:
+            self.boto3_client_alice.head_bucket(Bucket='test-bucket')
+        the_exception = e.exception
+        self.assertEqual(the_exception.response['ResponseMetadata']['HTTPStatusCode'], 403)
+
+        # alice can see alice-bucket
+        head_bucket_result = self.boto3_client_alice.head_bucket(Bucket='alice-bucket')
+        self.assertEqual(head_bucket_result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        # alice can see alice-bucket2
+        head_bucket_result = self.boto3_client_alice.head_bucket(Bucket='alice-bucket2')
+        self.assertEqual(head_bucket_result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        # bucket does not exist
+        with self.assertRaises(botocore.exceptions.ClientError) as e:
+            self.boto3_client_alice.head_bucket(Bucket='bucketdoesnotexist')
+        the_exception = e.exception
+        self.assertEqual(the_exception.response['ResponseMetadata']['HTTPStatusCode'], 403)

--- a/tests/headobject_test.py
+++ b/tests/headobject_test.py
@@ -32,7 +32,7 @@ class HeadObject_Test(TestCase):
                                         aws_secret_access_key=self.secret_key)
 
     def tearDown(self):
-        pass
+        self.boto3_client.close()
 
     # ======== Tests =========
 

--- a/tests/listbuckets_test.py
+++ b/tests/listbuckets_test.py
@@ -40,7 +40,8 @@ class ListBuckets_Test(TestCase):
                                             aws_secret_access_key=self.secret_key_alice)
 
     def tearDown(self):
-        pass
+        self.client_rods.close()
+        self.client_alice.close()
 
     # ======== Helper Functions =========
 

--- a/tests/putobject_test.py
+++ b/tests/putobject_test.py
@@ -31,7 +31,7 @@ class PutObject_Test(TestCase):
                                         aws_secret_access_key=self.secret_key)
 
     def tearDown(self):
-        pass
+        self.boto3_client.close()
 
     def test_botocore_put_in_bucket_root_small_file(self):
 

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -4,6 +4,7 @@ import copyobject_test
 import deleteobject_test
 import getobject_test
 import headobject_test
+import headbucket_test
 import listbuckets_test
 import listobject_test
 import putobject_test
@@ -12,10 +13,11 @@ import putobject_test
 def run_some_tests():
     # Run only the tests in the specified classes
 
-    test_classes_to_run = [getobject_test.GetObject_Test,
+    test_classes_to_run = [
             copyobject_test.CopyObject_Test,
             deleteobject_test.DeleteObject_Test,
             getobject_test.GetObject_Test,
+            headbucket_test.HeadBucket_Test,
             headobject_test.HeadObject_Test,
             listbuckets_test.ListBuckets_Test,
             listobject_test.ListObject_Test,


### PR DESCRIPTION
This handles five issues:

* 37 - Add disable multipart instructions for MinIO mc client.
* 46 - Implement chunk parsing when `boost::beast::http::parser` does not handle it.  This is specifically for MinIO clients which do not set the `Transfer-Encoding` header but sends a chunked body.  Added MinIO tests for put.
* 51 - Added HeadBucket functionality/tests.
* 67 - Close boto3 connections in tests.
* 69 - Double buffer on a put when the parser returns the `need_buffer` exception.  Also implement a maximum parse size.

Tests passed.