### PR TITLE
[87] move resource definition to irods_client side of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,6 @@ The following code block shows the structure of the configuration file and provi
             }
         },
 
-        // This may be relevant to your performance if you have many rules
-        // in your iRODS installation
-        "resource": "demoResc",
-
         // The number of threads dedicated to servicing client requests.
         "threads": 10,
 
@@ -183,6 +179,10 @@ The following code block shows the structure of the configuration file and provi
 
         // The zone of the target iRODS server.
         "zone": "<string>",
+
+        // This may be relevant to your performance if you have many rules
+        // in your iRODS installation
+        "resource": "demoResc",
 
         // The credentials for the rodsadmin user that will act as a proxy
         // for all authenticated users.

--- a/config.json.template
+++ b/config.json.template
@@ -21,8 +21,6 @@
             }
         },
 
-        "resource": "demoResc",
-
         "threads": 10,
 
         "put_object_buffer_size_in_bytes": 8192,
@@ -36,6 +34,8 @@
         "port": 1247,
 
         "zone": "tempZone",
+
+        "resource": "demoResc",
 
         "proxy_admin_account": {
             "username": "rods",

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -67,7 +67,7 @@ void irods::s3::set_resource(const std::string_view& resc)
 std::string irods::s3::get_resource()
 {
     if (!resource.has_value()) {
-        resource = g_config.value(nlohmann::json::json_pointer{"/s3_server/resource"}, std::string{});
+        resource = g_config.value(nlohmann::json::json_pointer{"/irods_client/resource"}, std::string{});
     }
     return resource.value();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -267,9 +267,10 @@ nlohmann::json load_configuration(const std::string_view _config_path, unsigned 
         std::cout << "Loading plugin " << k << std::endl;
         irods::s3::plugins::load_plugin(*i, k, v);
     }
-    if (s3_server.find("resource") != s3_server.end()) {
-        irods::s3::set_resource(s3_server.value<std::string>("resource", ""));
-    }
+
+    using json_pointer = nlohmann::json::json_pointer;
+    irods::s3::set_resource(config_value.value<std::string>(json_pointer{"/irods_client/resource"}, ""));
+
     port = s3_server.value("port", 8080);
 
     if (!irods::s3::plugins::authentication_plugin_loaded()) {

--- a/tests/docker/config.json
+++ b/tests/docker/config.json
@@ -27,12 +27,13 @@
             }
         },
 
-        "resource": "demoResc",
-
         "threads": 10,
+
         "put_object_buffer_size_in_bytes": 8192,
         "put_object_max_buffer_size_in_bytes": 65536,
-        "get_object_buffer_size_in_bytes": 8192 
+        "get_object_buffer_size_in_bytes": 8192,
+        "region": "us-east-1"
+
     },
 
     "irods_client": {
@@ -40,6 +41,8 @@
         "port": 1247,
 
         "zone": "tempZone",
+
+        "resource": "newResc",
 
         "proxy_admin_account": {
             "username": "rods",

--- a/tests/docker/start.irods.ubuntu20.sh
+++ b/tests/docker/start.irods.ubuntu20.sh
@@ -22,6 +22,9 @@ sudo -H -u irods bash -c "iadmin moduser user1 password user1"
 sudo -H -u irods bash -c "iadmin mkuser alice rodsuser"
 sudo -H -u irods bash -c "iadmin moduser alice password apass"
 
+#### Create newResc resource in iRODS ####
+sudo -H -u irods bash -c "iadmin mkresc newResc unixfilesystem `hostname`:/tmp/newRescVault"
+
 #### Give root an environment to connect to iRODS ####
 echo 'localhost
 1247


### PR DESCRIPTION
Pretty sure this also needs to be updated/changed/moved...

https://github.com/irods/irods_client_s3_api/blob/1c767a443b68b56e2b1466d52bc9035396b39186/src/main.cpp#L270-L272

Input welcome.