### PR TITLE
[#111,irods/irods#6251,irods/irods#6256,irods/irods#7265] Remove stray coroutine includes, use find_package for fmt and spdlog, and touch-up CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,11 @@ find_package(CURL REQUIRED)
 find_package(nlohmann_json "3.6.1" REQUIRED)
 find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
 
+if (IRODS_VERSION VERSION_GREATER "4.3.1")
+  find_package(fmt "8.1.1"
+    HINTS "${IRODS_EXTERNALS_FULLPATH_FMT}")
+endif()
+
 include(ObjectTargetHelpers)
 
 add_subdirectory(core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_CXX_STANDARD ${IRODS_CXX_STANDARD})
 set(CMAKE_CXX_EXTENSIONS OFF)
 # export-dynamic so stacktrace entries from executables have function names.
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--export-dynamic -Wl,--enable-new-dtags -Wl,--as-needed")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT "-Wl,--gc-sections -Wl,-z,combreloc")
 include(IrodsRunpathDefaults)
 
 project(${IRODS_S3_API_BINARY_NAME} VERSION "${IRODS_S3_API_VERSION}" LANGUAGES CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
 if (IRODS_VERSION VERSION_GREATER "4.3.1")
   find_package(fmt "8.1.1"
     HINTS "${IRODS_EXTERNALS_FULLPATH_FMT}")
+  find_package(spdlog "1.9.2"
+    HINTS "${IRODS_EXTERNALS_FULLPATH_SPDLOG}")
 endif()
 
 include(ObjectTargetHelpers)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -56,7 +56,6 @@ target_include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
 
 if (IRODS_VERSION VERSION_GREATER "4.3.1")
@@ -64,6 +63,7 @@ if (IRODS_VERSION VERSION_GREATER "4.3.1")
     irods_s3_api_core
     PUBLIC
     fmt::fmt
+    spdlog::spdlog
   )
 else()
   target_link_libraries(
@@ -76,6 +76,7 @@ else()
     irods_s3_api_core
     PRIVATE
     "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
   )
 endif()
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_program_options.so"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_url.so"
-  "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
   CURL::libcurl
   hmac_sha256
 )
@@ -57,8 +56,27 @@ target_include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
   "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
+
+if (IRODS_VERSION VERSION_GREATER "4.3.1")
+  target_link_libraries(
+    irods_s3_api_core
+    PUBLIC
+    fmt::fmt
+  )
+else()
+  target_link_libraries(
+    irods_s3_api_core
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+  )
+
+  target_include_directories(
+    irods_s3_api_core
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+  )
+endif()
 
 set_target_properties(irods_s3_api_core PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/authentication/CMakeLists.txt
+++ b/endpoints/authentication/CMakeLists.txt
@@ -26,8 +26,27 @@ target_include_directories(
   "${IRODS_S3_API_PROJECT_BINARY_DIR}/core/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
   "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
+
+if (IRODS_VERSION VERSION_GREATER "4.3.1")
+  target_link_libraries(
+    irods_s3_api_endpoint_authentication
+    PUBLIC
+    fmt::fmt
+  )
+else()
+  target_link_libraries(
+    irods_s3_api_endpoint_authentication
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+  )
+
+  target_include_directories(
+    irods_s3_api_endpoint_authentication
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+  )
+endif()
 
 set_target_properties(irods_s3_api_endpoint_authentication PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/authentication/CMakeLists.txt
+++ b/endpoints/authentication/CMakeLists.txt
@@ -26,7 +26,6 @@ target_include_directories(
   "${IRODS_S3_API_PROJECT_BINARY_DIR}/core/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
 
 if (IRODS_VERSION VERSION_GREATER "4.3.1")
@@ -34,6 +33,7 @@ if (IRODS_VERSION VERSION_GREATER "4.3.1")
     irods_s3_api_endpoint_authentication
     PUBLIC
     fmt::fmt
+    spdlog::spdlog
   )
 else()
   target_link_libraries(
@@ -46,6 +46,7 @@ else()
     irods_s3_api_endpoint_authentication
     PRIVATE
     "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
   )
 endif()
 

--- a/endpoints/put_object/CMakeLists.txt
+++ b/endpoints/put_object/CMakeLists.txt
@@ -26,8 +26,27 @@ target_include_directories(
   "${IRODS_S3_API_PROJECT_BINARY_DIR}/core/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
   "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
+
+if (IRODS_VERSION VERSION_GREATER "4.3.1")
+  target_link_libraries(
+    irods_s3_api_endpoint_put_object
+    PUBLIC
+    fmt::fmt
+  )
+else()
+  target_link_libraries(
+    irods_s3_api_endpoint_put_object
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+  )
+
+  target_include_directories(
+    irods_s3_api_endpoint_put_object
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+  )
+endif()
 
 set_target_properties(irods_s3_api_endpoint_put_object PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/put_object/CMakeLists.txt
+++ b/endpoints/put_object/CMakeLists.txt
@@ -26,7 +26,6 @@ target_include_directories(
   "${IRODS_S3_API_PROJECT_BINARY_DIR}/core/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
 
 if (IRODS_VERSION VERSION_GREATER "4.3.1")
@@ -34,6 +33,7 @@ if (IRODS_VERSION VERSION_GREATER "4.3.1")
     irods_s3_api_endpoint_put_object
     PUBLIC
     fmt::fmt
+    spdlog::spdlog
   )
 else()
   target_link_libraries(
@@ -46,6 +46,7 @@ else()
     irods_s3_api_endpoint_put_object
     PRIVATE
     "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
   )
 endif()
 

--- a/endpoints/s3/CMakeLists.txt
+++ b/endpoints/s3/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(
   irods_s3_endpoints
   PRIVATE
   irods_client
-  CURL::libcurl
   nlohmann_json::nlohmann_json
 )
 

--- a/endpoints/s3/CMakeLists.txt
+++ b/endpoints/s3/CMakeLists.txt
@@ -35,7 +35,6 @@ target_include_directories(
   "${IRODS_S3_API_PROJECT_BINARY_DIR}/core/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
 
 if (IRODS_VERSION VERSION_GREATER "4.3.1")
@@ -43,6 +42,7 @@ if (IRODS_VERSION VERSION_GREATER "4.3.1")
     irods_s3_endpoints
     PUBLIC
     fmt::fmt
+    spdlog::spdlog
   )
 else()
   target_link_libraries(
@@ -55,6 +55,7 @@ else()
     irods_s3_endpoints
     PRIVATE
     "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
   )
 endif()
 

--- a/endpoints/s3/CMakeLists.txt
+++ b/endpoints/s3/CMakeLists.txt
@@ -35,8 +35,27 @@ target_include_directories(
   "${IRODS_S3_API_PROJECT_BINARY_DIR}/core/include"
   "${IRODS_S3_API_PROJECT_SOURCE_DIR}/endpoints/shared/include"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
-  "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
   "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
 )
+
+if (IRODS_VERSION VERSION_GREATER "4.3.1")
+  target_link_libraries(
+    irods_s3_endpoints
+    PUBLIC
+    fmt::fmt
+  )
+else()
+  target_link_libraries(
+    irods_s3_endpoints
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
+  )
+
+  target_include_directories(
+    irods_s3_endpoints
+    PRIVATE
+    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
+  )
+endif()
 
 set_target_properties(irods_s3_endpoints PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/s3/src/listbuckets.cpp
+++ b/endpoints/s3/src/listbuckets.cpp
@@ -10,7 +10,6 @@
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/this_coro.hpp>
-#include <experimental/coroutine>
 #include <boost/beast.hpp>
 
 #include <boost/asio.hpp>

--- a/endpoints/s3/src/listobjects.cpp
+++ b/endpoints/s3/src/listobjects.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/this_coro.hpp>
-#include <experimental/coroutine>
 #include <boost/beast.hpp>
 
 #include <boost/asio.hpp>


### PR DESCRIPTION
Addresses #111
In service of irods/irods#6251
In service of irods/irods#6256
In service of irods/irods#7265