### PR TITLE
[#96] Avoid infinite loop when listening socket is already bound

### DIFF
--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -97,35 +97,10 @@ class listener : public std::enable_shared_from_this<listener>
 	                         .get<int>()}
 		, timeout_in_secs_{_config.at(json::json_pointer{"/s3_server/requests/timeout_in_seconds"}).get<int>()}
 	{
-		beast::error_code ec;
-
-		// Open the acceptor
-		acceptor_.open(endpoint.protocol(), ec);
-		if (ec) {
-			irods::fail(ec, "open");
-			return;
-		}
-
-		// Allow address reuse
-		acceptor_.set_option(net::socket_base::reuse_address(true), ec);
-		if (ec) {
-			irods::fail(ec, "set_option");
-			return;
-		}
-
-		// Bind to the server address
-		acceptor_.bind(endpoint, ec);
-		if (ec) {
-			irods::fail(ec, "bind");
-			return;
-		}
-
-		// Start listening for connections
-		acceptor_.listen(net::socket_base::max_listen_connections, ec);
-		if (ec) {
-			irods::fail(ec, "listen");
-			return;
-		}
+		acceptor_.open(endpoint.protocol());
+		acceptor_.set_option(net::socket_base::reuse_address(true));
+		acceptor_.bind(endpoint);
+		acceptor_.listen(net::socket_base::max_listen_connections);
 	} // listener (constructor)
 
 	// Start accepting incoming connections.


### PR DESCRIPTION
When the target port is already bound, attempts to launch a second server will result in messages like the following before the server terminates.
```
[2024-09-25 14:49:41.286] [P:565918] [info] [T:565918] Initializing server.
[2024-09-25 14:49:41.287] [P:565918] [trace] [T:565918] Loading API plugins.
[2024-09-25 14:49:41.319] [P:565918] [trace] [T:565918] Initializing TLS.
[2024-09-25 14:49:41.319] [P:565918] [trace] [T:565918] Setting environment variable [IRODS_CLIENT_SERVER_POLICY] to [CS_NEG_REFUSE].
[2024-09-25 14:49:41.319] [P:565918] [trace] [T:565918] Setting environment variable [IRODS_SSL_VERIFY_SERVER] to [cert].
[2024-09-25 14:49:41.319] [P:565918] [trace] [T:565918] Initializing iRODS connection pool.
[2024-09-25 14:49:41.490] [P:565918] [trace] [T:565918] Initializing HTTP components.
[2024-09-25 14:49:41.490] [P:565918] [trace] [T:565918] Initializing listening socket (host=[0.0.0.0], port=[9000]).
Error: bind: Address already in use [system:98 at /opt/irods-externals/boost1.81.0-1/include/boost/asio/detail/reactive_socket_service.hpp:161:33 in function 'bind']
```